### PR TITLE
modified example test_sum_is_positive

### DIFF
--- a/hypothesis-python/docs/details.rst
+++ b/hypothesis-python/docs/details.rst
@@ -250,7 +250,7 @@ Here's what happens if we try to run this:
 
   @given(lists(integers()))
   def test_sum_is_positive(xs):
-      assume(len(xs) > 10)
+      assume(len(xs) > 1)
       assume(all(x > 0 for x in xs))
       print(xs)
       assert sum(xs) > 0


### PR DESCRIPTION
If using len(xs)> 2 or 10 or anythign greater than 1, it will return lists with a greater likelihood to contain negative numbers, which will fail in the next line.